### PR TITLE
change -all flag to remove whole group

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,13 @@ Usage: swach azure [OPTIONS]
   Cleanup Azure provider
 
 Options:
-  --all    Remove all unused Resources from the provider
-  --nics   Remove only unused NICs from the provider
-  --discs  Remove only unused DISCs from the provider
-  --vms    Remove only unused VMs from the provider
-  --pips   Remove only PiPs from the provider
-  --help   Show this message and exit.
+  --all             Remove all unused Resources from the provider
+  --all_rg          Remove resource group only if all resources are older than SLA
+  --nics            Remove only unused NICs from the provider
+  --discs           Remove only unused DISCs from the provider
+  --vms             Remove only unused VMs from the provider
+  --pips            Remove only PiPs from the provider
+  --help            Show this message and exit.
 
 ```
 
@@ -122,11 +123,11 @@ VMs:
 	Deletable: ['test-bvhoduliam']
 	Stoppable: ['foremanqe-nightly2']
 DISCs:
-	Deletable: ['test-axodawttrw-nic0']
+	Deletable: ['test-bvhoduliam-osdisk']
 NICs:
 	Deletable: ['test-axodawttrw-nic0']
 PIPs:
-	Deletable: ['test-axodawttrw-nic0']
+	Deletable: ['test-axodawttrw-pip0']
 ====================================
 ```
 

--- a/cloudwash/cli.py
+++ b/cloudwash/cli.py
@@ -52,13 +52,14 @@ def gce(ctx, vms, discs, nics, _all):
 @cleanup_providers.command(help='Cleanup Azure provider')
 @common_options
 @click.option('--pips', is_flag=True, help='Remove only PiPs from the provider')
+@click.option('--all_rg', '_all_rg', is_flag=True, help='Remove resource group only if all resources are older than SLA')
 @click.pass_context
-def azure(ctx, vms, discs, nics, pips, _all):
+def azure(ctx, vms, discs, nics, pips, _all, _all_rg):
     # Validate Azure Settings
     validate_provider(ctx.command.name)
     is_dry_run = ctx.parent.params['dry']
     azureCleanup(
-        vms=vms, discs=discs, nics=nics, pips=pips, _all=_all, dry_run=is_dry_run)
+        vms=vms, discs=discs, nics=nics, pips=pips, _all=_all, _all_rg=_all_rg, dry_run=is_dry_run)
 
 
 @cleanup_providers.command(help='Cleanup Amazon provider')

--- a/cloudwash/providers/azure.py
+++ b/cloudwash/providers/azure.py
@@ -54,6 +54,10 @@ def cleanup(**kwargs):
             [dry_data['PIPS']['delete'].append(dpip) for dpip in rpips]
             return rpips
 
+        def dry_resources(hours_old=None):
+            dry_data['RESOURCES']['delete'] = azure_client.list_resources_from_hours_old(hours_old=hours_old or (settings.sla_minutes / 60))
+            return dry_data['RESOURCES']['delete']
+
         # Remove / Stop VMs
         def remove_vms(avms):
             # Remove VMs
@@ -83,5 +87,10 @@ def cleanup(**kwargs):
             if not is_dry_run:
                 azure_client.remove_pips_by_search()
                 logger.info(f'Removed following and all unused pips from Azure Cloud. \n{rpips}')
+        if kwargs['_all_rg']:
+            rres = dry_resources()
+            if not is_dry_run:
+                azure_client.remove_resource_group_of_old_resources(hours_old=(settings.sla_minutes / 60))
+                logger.info(f'Removed following and all unused resources from Azure Cloud. \n{rres}')
         if is_dry_run:
             echo_dry(dry_data)

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -6,7 +6,7 @@ from cloudwash.logger import logger
 import pytz
 
 _vms_dict = {'VMS': {'delete': [], 'stop': []}}
-dry_data = {'NICS': {'delete': []}, 'DISCS': {'delete': []}, 'PIPS': {'delete': []}}
+dry_data = {'NICS': {'delete': []}, 'DISCS': {'delete': []}, 'PIPS': {'delete': []}, 'RESOURCES': {'delete': []}}
 dry_data.update(_vms_dict)
 
 
@@ -22,6 +22,7 @@ def echo_dry(dry_data=None) -> None:
     deletable_discs = dry_data["DISCS"]['delete']
     deletable_nics = dry_data["NICS"]['delete']
     deletable_pips = dry_data["PIPS"]['delete'] if 'PIPS' in dry_data else None
+    deletable_resources = dry_data["RESOURCES"]['delete']
 
     if deletable_vms or stopable_vms:
         logger.info(f'VMs:\n\tDeletable: {deletable_vms}\n\tStoppable: {stopable_vms}')
@@ -31,7 +32,9 @@ def echo_dry(dry_data=None) -> None:
         logger.info(f'NICs:\n\tDeletable: {deletable_nics}')
     if deletable_pips:
         logger.info(f'PIPs:\n\tDeletable: {deletable_pips}')
-    if not any([deletable_vms, stopable_vms, deletable_discs, deletable_nics, deletable_pips]):
+    if deletable_resources:
+        logger.info(f'RESOURCEs:\n\tDeletable: {deletable_resources}')
+    if not any([deletable_vms, stopable_vms, deletable_discs, deletable_nics, deletable_pips, deletable_resources]):
         logger.info('No resources are eligible for cleanup!')
     logger.info('\n====================================\n')
 


### PR DESCRIPTION
delete whole resource group with `--all`  if all resources are older than SLA. deleting individual resources would be difficult due to inability to delete dependent resources.

depends on: https://github.com/RedHatQE/wrapanapi/pull/453