### PR TITLE
added .profile file to keep environment variables

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,6 +22,9 @@ RUN git clone --depth=1 https://github.com/RedHatQE/cloudwash.git && \
 # Download conf file
 RUN curl -o ${CLOUDWASH_DIR}/settings.yaml https://raw.githubusercontent.com/RedHatQE/cloudwash/master/settings.yaml.template
 
+# adding .profile to environment variables, so it will be kept between shell sessions
+RUN echo "source ${VIRTUAL_ENV}/.profile" >> ${VIRTUAL_ENV}/bin/activate && touch ${VIRTUAL_ENV}/.profile
+
 # arbitrary UID handling starting from virtualenv directory for pip permissions
 USER 0
 RUN chgrp -R 0 ${VIRTUAL_ENV} && \

--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -19,6 +19,9 @@ RUN pip install azure-mgmt-media==1.0.0rc2
 RUN mkdir -p ${CLOUDWASH_DIR}
 RUN curl -o ${CLOUDWASH_DIR}/settings.yaml https://raw.githubusercontent.com/RedHatQE/cloudwash/master/settings.yaml.template
 
+# adding .profile to environment variables, so it will be kept between shell sessions
+RUN echo "source ${VIRTUAL_ENV}/.profile" >> ${VIRTUAL_ENV}/bin/activate && touch ${VIRTUAL_ENV}/.profile
+
 # arbitrary UID handling starting from virtualenv directory for pip permissions
 USER 0
 RUN chgrp -R 0 ${VIRTUAL_ENV} && \


### PR DESCRIPTION
Hello guys,

As cloudwash is accepting ENV variables for secrets, and also have a virtual environment configured in the container, it creates a challenge:
Environment variable that was created in session A, will not be available for session B (same container).

To overcome it, I added a .profile file that can be modified by the user in session A, and make the environment variable available for session B as well.

Let me know what you think.