### PR TITLE
remove git history from image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN yum -y clean all
 # Installing cloudwash
 USER 1001
 WORKDIR "${HOME}"
-RUN git clone https://github.com/RedHatQE/cloudwash.git && \
+RUN git clone --depth=1 https://github.com/RedHatQE/cloudwash.git && \
     cd ${CLOUDWASH_DIR} && \
     pip install --upgrade pip && \
     pip install -r requirements.txt


### PR DESCRIPTION
Hello,

As a docker image size best practice, git depth was lowered to 1, so git history will not be downloaded to the image.
Currently, disk space difference is not dramatic (saves 8KB), but as we will have more branches / more commits, it can be substantial.

Thanks.