### PR TITLE
Dockerfile.dev installs from setup.cfg instead of requirements

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,12 +15,10 @@ WORKDIR "${HOME}"
 RUN git clone --depth=1 https://github.com/RedHatQE/cloudwash.git && \
     cd ${CLOUDWASH_DIR} && \
     pip install --upgrade pip && \
-    pip install -r requirements.txt
+    pip install . && \
+    cp settings.yaml.template settings.yaml
 # Workaround for the issue DistributionNotFound: The 'azure-mgmt-media~=1.0.0rc2' distribution was not found and is required by azure-mgmt
 # RUN pip install azure-mgmt-media==1.0.0rc2
-
-# Download conf file
-RUN curl -o ${CLOUDWASH_DIR}/settings.yaml https://raw.githubusercontent.com/RedHatQE/cloudwash/master/settings.yaml.template
 
 # adding .profile to environment variables, so it will be kept between shell sessions
 RUN echo "source ${VIRTUAL_ENV}/.profile" >> ${VIRTUAL_ENV}/bin/activate && touch ${VIRTUAL_ENV}/.profile


### PR DESCRIPTION
With the recent change from #24 , the development docker images should now install from setup as requirements file is removed.