### PR TITLE
Fix PyPi failing with cloudwash setup

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -57,7 +57,13 @@ jobs:
 
       - name: Setup and Build
         run: |
+          sudo apt update
+          sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
+          # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
+          # then compile and install it with PYCURL_SSL_LIBRARY set to openssl
           pip install -U pip
+          pip uninstall -y pycurl
+          pip install --compile --no-cache-dir pycurl
           pip install .[setup]
           python setup.py sdist
           python -m twine check dist/*


### PR DESCRIPTION
Auto PyPi release failing with PyCurl https://github.com/RedHatQE/cloudwash/runs/7061757863?check_suite_focus=true. This PR fixes that. 