### PR TITLE
Added comments for aws credentials on settings template file

### DIFF
--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -26,7 +26,9 @@ PROVIDERS:
     EXCEPT_VM_STOP_LIST: []
 
   EC2:
+    # ACCESS_KEY can be used as username
     USERNAME:
+    # SECRET_KEY can be used as password
     PASSWORD:
     # Multiple regions can be added like ["ap-south-1", "us-west-2", "us-west-1"] or ["all"] for all regions
     REGIONS: []


### PR DESCRIPTION
This PR will add comments on `AWS` credentials to make explicit the equivalences for `ACCESS_KEY` and `SECRET_KEY` on the settings file for EC2 provider