### PR TITLE
Bugfix & remove redundant template parameters

### DIFF
--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -25,11 +25,11 @@ def cleanup(**kwargs):
             def dry_vms():
                 all_vms = aws_client.list_vms()
                 for vm in all_vms:
-                    if vm.name in settings.aws.exception.vm.vm_list:
+                    if vm.name in settings.aws.exceptions.vm.vm_list:
                         dry_data["VMS"]["skip"].append(vm.name)
                         continue
                     elif total_running_time(vm).minutes >= settings.aws.criteria.vm.sla_minutes:
-                        if vm.name in settings.aws.exception.vm.stop_list:
+                        if vm.name in settings.aws.exceptions.vm.stop_list:
                             dry_data["VMS"]["stop"].append(vm.name)
                             continue
                         elif vm.name.startswith(settings.aws.criteria.vm.delete_vm):

--- a/cloudwash/providers/azure.py
+++ b/cloudwash/providers/azure.py
@@ -19,7 +19,7 @@ def _dry_vms(all_vms):
         if vm.state.lower() == "vmstate.creating":
             continue
         # Match the user defined criteria in settings to delete the VM
-        if vm.name in settings.azure.exception.vm.vm_list:
+        if vm.name in settings.azure.exceptions.vm.vm_list:
             _vms["skip"].append(vm.name)
             continue
         elif (
@@ -28,7 +28,7 @@ def _dry_vms(all_vms):
             )
             >= settings.azure.criteria.vm.sla_minutes
         ):
-            if vm.name in settings.azure.exception.vm.stop_list:
+            if vm.name in settings.azure.exceptions.vm.stop_list:
                 _vms["stop"].append(vm.name)
                 continue
             elif vm.name.startswith(settings.azure.criteria.vm.delete_vm):

--- a/cloudwash/providers/gce.py
+++ b/cloudwash/providers/gce.py
@@ -15,11 +15,11 @@ def cleanup(**kwargs):
         if kwargs["vms"] or kwargs["_all"]:
             allvms = gce_client.list_vms(zones=gce_zones())
             for vm in allvms:
-                if vm.name in settings.gce.exception.vm.vm_list:
+                if vm.name in settings.gce.exceptions.vm.vm_list:
                     dry_data["VMS"]["skip"].append(vm.name)
                     continue
                 elif total_running_time(vm).minutes >= settings.gce.criteria.vm.sla_minutes:
-                    if vm.name in settings.gce.exception.vm.stop_list:
+                    if vm.name in settings.gce.exceptions.vm.stop_list:
                         dry_data["VMS"]["stop"].append(vm.name)
                         if not is_dry_run:
                             try:

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -12,10 +12,6 @@ AWS:
             DELETE_VM: 'test'
             # Number of minutes the deletable VM should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
-            # VMs that would be skipped from cleanup
-            EXCEPT_VM_LIST: []
-            # VMs that would be stopped from running states
-            EXCEPT_VM_STOP_LIST: []
         DISC:
             UNASSIGNED: True
         NIC:

--- a/conf/azure.yaml.template
+++ b/conf/azure.yaml.template
@@ -14,10 +14,6 @@ AZURE:
             DELETE_VM: 'test'
             # Number of minutes the deletable VM should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
-            # VMs that would be skipped from cleanup
-            EXCEPT_VM_LIST: []
-            # VMs that would be stopped from running states
-            EXCEPT_VM_STOP_LIST: []
         DISC:
             UNASSIGNED: True
         NIC:

--- a/conf/gce.yaml.template
+++ b/conf/gce.yaml.template
@@ -10,10 +10,6 @@ GCE:
             DELETE_VM: 'test'
             # Number of minutes the deletable VM should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
-            # VMs that would be skipped from cleanup
-            EXCEPT_VM_LIST: []
-            # VMs that would be stopped from running states
-            EXCEPT_VM_STOP_LIST: []
         DISC:
             UNASSIGNED: True
         NIC:

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -12,10 +12,6 @@ GCE:
             DELETE_VM: 'test'
             # Number of minutes the deletable VM should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
-            # VMs that would be skipped from cleanup
-            EXCEPT_VM_LIST: []
-            # VMs that would be stopped from running states
-            EXCEPT_VM_STOP_LIST: []
         DISC:
             UNASSIGNED: True
         NIC:
@@ -69,10 +65,6 @@ AWS:
             DELETE_VM: 'test'
             # Number of minutes the deletable VM should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
-            # VMs that would be skipped from cleanup
-            EXCEPT_VM_LIST: []
-            # VMs that would be stopped from running states
-            EXCEPT_VM_STOP_LIST: []
         DISC:
             UNASSIGNED: True
         NIC:


### PR DESCRIPTION
Found typo putting exception instead of exceptions breaking VM exception functionality for all cloud providers. cc @jyejare 