### PR TITLE
Fixes #68 - Fix Typo in Compute based settings

### DIFF
--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -1,9 +1,7 @@
 AWS:
     AUTH:
-        # ACCESS_KEY can be used as username
-        USERNAME:
-        # SECRET_KEY can be used as password
-        PASSWORD:
+        ACCESS_KEY:
+        SECRET_KEY:
         # Multiple regions can be added like ["ap-south-1", "us-west-2", "us-west-1"] or ["all"] for all regions
         REGIONS: []
     CRITERIA:

--- a/conf/azure.yaml.template
+++ b/conf/azure.yaml.template
@@ -1,9 +1,7 @@
 AZURE:
     AUTH:
-        # CLIENT_ID
-        USERNAME:
-        # SECRET_ID
-        PASSWORD:
+        CLIENT_ID:
+        SECRET_ID:
         TENANT_ID:
         SUBSCRIPTION_ID:
         RESOURCE_GROUP:


### PR DESCRIPTION
Fixes #68 

Aligning settings Compute bases settings-files settings names with settings.yaml.template that fixes the issue of settings names mismatched in two different settings files.