### PR TITLE
Update Dockerfile and GitHub Actions to use Python 3.11

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -13,14 +13,17 @@ jobs:
   codechecks:
     name: Code Quality
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - name: Checkout Cloudwash
         uses: actions/checkout@v3
 
-      - name: Set Up Python3
+      - name: Set Up Python-${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
         run: |
@@ -53,7 +56,7 @@ jobs:
       - name: Set Up Python3
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Setup and Build
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,14 +12,17 @@ jobs:
   codechecks:
     name: Code Quality
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - name: Checkout Cloudwash
         uses: actions/checkout@v3
 
-      - name: Set Up Python3
+      - name: Set Up Python-${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
         run: |

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,10 @@
-FROM registry.access.redhat.com/ubi8/python-38:latest
+FROM quay.io/fedora/python-311:latest
 MAINTAINER "https://github.com/RedHatQE"
 
-ENV VIRTUAL_ENV="/opt/app-root" \
-    HOME="/opt/app-root/src" \
-    CLOUDWASH_DIR="/opt/app-root/src/cloudwash" \
+# HOME and APP_ROOT come from the base image - https://github.com/sclorg/s2i-python-container
+# HOME=/opt/app-root/src
+# APP_ROOT=/opt/app-root
+ENV CLOUDWASH_DIR="${HOME}/cloudwash" \
     PYCURL_SSL_LIBRARY=openssl
 
 USER 0
@@ -21,13 +22,11 @@ RUN git clone --depth=1 https://github.com/RedHatQE/cloudwash.git && \
 RUN /bin/bash -c 'cd ${CLOUDWASH_DIR}; for conffile in conf/*.yaml.template; do cp -- "$conffile" "${conffile%.yaml.template}.yaml"; done'
 
 # adding .profile to environment variables, so it will be kept between shell sessions
-RUN echo "source ${VIRTUAL_ENV}/.profile" >> ${VIRTUAL_ENV}/bin/activate && touch ${VIRTUAL_ENV}/.profile
+RUN echo "source ${APP_ROOT}/.profile" >> ${APP_ROOT}/bin/activate && touch ${APP_ROOT}/.profile
 
 # arbitrary UID handling starting from virtualenv directory for pip permissions
 USER 0
-RUN chgrp -R 0 ${VIRTUAL_ENV} && \
-    chmod -R g+rwX ${VIRTUAL_ENV} && \
-    fix-permissions ${VIRTUAL_ENV} -P
-
+RUN fix-permissions ${APP_ROOT} -P && \
+    git config --global --add safe.directory ${CLOUDWASH_DIR}
 USER 1001
 WORKDIR "${CLOUDWASH_DIR}"


### PR DESCRIPTION
This PR updates cloudwash's Dockerfile to use Python 3.11. The `python-311` image is built the same way as the UBI images, so the difference between them is minimal.