### PR TITLE
Adding image cleanup for clouds

### DIFF
--- a/cloudwash/cli.py
+++ b/cloudwash/cli.py
@@ -94,15 +94,23 @@ def azure(ctx, vms, discs, nics, images, pips, _all, _all_rg):
 
 @cleanup_providers.command(help="Cleanup Amazon provider")
 @common_options
+@click.option("--images", is_flag=True, help="Remove only images from the provider")
 @click.option("--pips", is_flag=True, help="Remove only Public IPs from the provider")
 @click.option("--stacks", is_flag=True, help="Remove only CloudFormations from the provider")
 @click.pass_context
-def aws(ctx, vms, discs, nics, pips, stacks, _all):
+def aws(ctx, vms, discs, nics, images, pips, stacks, _all):
     # Validate Amazon Settings
     validate_provider(ctx.command.name)
     is_dry_run = ctx.parent.params["dry"]
     awsCleanup(
-        vms=vms, discs=discs, nics=nics, pips=pips, stacks=stacks, _all=_all, dry_run=is_dry_run
+        vms=vms,
+        discs=discs,
+        nics=nics,
+        images=images,
+        pips=pips,
+        stacks=stacks,
+        _all=_all,
+        dry_run=is_dry_run,
     )
 
 

--- a/cloudwash/cli.py
+++ b/cloudwash/cli.py
@@ -67,6 +67,7 @@ def gce(ctx, vms, discs, nics, _all):
 
 @cleanup_providers.command(help="Cleanup Azure provider")
 @common_options
+@click.option("--images", is_flag=True, help="Remove only images from the provider")
 @click.option("--pips", is_flag=True, help="Remove only PiPs from the provider")
 @click.option(
     "--all_rg",
@@ -75,7 +76,7 @@ def gce(ctx, vms, discs, nics, _all):
     help="Remove resource group only if all resources are older than SLA",
 )
 @click.pass_context
-def azure(ctx, vms, discs, nics, pips, _all, _all_rg):
+def azure(ctx, vms, discs, nics, images, pips, _all, _all_rg):
     # Validate Azure Settings
     validate_provider(ctx.command.name)
     is_dry_run = ctx.parent.params["dry"]
@@ -83,6 +84,7 @@ def azure(ctx, vms, discs, nics, pips, _all, _all_rg):
         vms=vms,
         discs=discs,
         nics=nics,
+        images=images,
         pips=pips,
         _all=_all,
         _all_rg=_all_rg,

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -57,7 +57,7 @@ def cleanup(**kwargs):
                 rimages = []
                 if settings.aws.criteria.image.unassigned:
                     rimages = aws_client.list_templates(executable_by_me=False, owned_by_me=True)
-                    free_images = aws_client.filter_free_images(
+                    free_images = aws_client.list_free_images(
                         image_list=[image.raw.image_id for image in rimages]
                     )
                     remove_images = [
@@ -65,11 +65,11 @@ def cleanup(**kwargs):
                         for image in free_images
                         if image not in settings.aws.exceptions.images
                     ]
-                    if settings.aws.criteria.image.delete_pattern:
+                    if settings.aws.criteria.image.delete_image:
                         remove_images = [
                             image
                             for image in remove_images
-                            if not image.startswith(settings.aws.criteria.image.delete_pattern)
+                            if image.startswith(settings.aws.criteria.image.delete_image)
                         ]
                     dry_data["IMAGES"]["delete"].extend(remove_images)
                 return remove_images

--- a/cloudwash/providers/azure.py
+++ b/cloudwash/providers/azure.py
@@ -110,13 +110,11 @@ def cleanup(**kwargs):
                             for image in image_names
                             if image not in settings.azure.exceptions.images
                         ]
-                        if settings.azure.criteria.image.delete_pattern:
+                        if settings.azure.criteria.image.delete_image:
                             remove_images = [
                                 image
                                 for image in remove_images
-                                if not image.startswith(
-                                    settings.azure.criteria.image.delete_pattern
-                                )
+                                if image.startswith(settings.azure.criteria.image.delete_image)
                             ]
                         dry_data["IMAGES"]["delete"].extend(remove_images)
                     return remove_images
@@ -156,7 +154,7 @@ def cleanup(**kwargs):
                 if kwargs["images"] or kwargs["_all"]:
                     rimages = dry_images()
                     if not is_dry_run and rimages:
-                        azure_client.delete_compute_image_by_name(image_list=rimages)
+                        azure_client.delete_compute_image_by_resource_group(image_list=rimages)
                         logger.info(f"Removed Images: \n{rimages}")
 
                 if kwargs["_all_rg"]:

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -13,6 +13,7 @@ dry_data = {
     "PIPS": {"delete": []},
     "RESOURCES": {"delete": []},
     "STACKS": {"delete": []},
+    "IMAGES": {"delete": []},
 }
 dry_data.update(_vms_dict)
 
@@ -29,6 +30,7 @@ def echo_dry(dry_data=None) -> None:
     skipped_vms = dry_data["VMS"]["skip"]
     deletable_discs = dry_data["DISCS"]["delete"]
     deletable_nics = dry_data["NICS"]["delete"]
+    deletable_images = dry_data["IMAGES"]["delete"]
     deletable_pips = dry_data["PIPS"]["delete"] if "PIPS" in dry_data else None
     deletable_resources = dry_data["RESOURCES"]["delete"]
     deletable_stacks = dry_data["STACKS"]["delete"] if "STACKS" in dry_data else None
@@ -41,6 +43,8 @@ def echo_dry(dry_data=None) -> None:
         logger.info(f"DISCs:\n\tDeletable: {deletable_discs}")
     if deletable_nics:
         logger.info(f"NICs:\n\tDeletable: {deletable_nics}")
+    if deletable_images:
+        logger.info(f"IMAGES:\n\tDeletable: {deletable_images}")
     if deletable_pips:
         logger.info(f"PIPs:\n\tDeletable: {deletable_pips}")
     if deletable_resources:
@@ -56,6 +60,7 @@ def echo_dry(dry_data=None) -> None:
             deletable_pips,
             deletable_resources,
             deletable_stacks,
+            deletable_images,
         ]
     ):
         logger.info("\nNo resources are eligible for cleanup!")

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -14,6 +14,11 @@ AWS:
             UNASSIGNED: True
         NIC:
             UNASSIGNED: True
+        IMAGE:
+            # Image name starts with
+            DELETE_IMAGE:
+
+            UNASSIGNED: True
         PUBLIC_IP:
             UNASSIGNED: True
         STACKS:
@@ -30,3 +35,4 @@ AWS:
         STACKS:
             # CloudFormations names that would be skipped from cleanup
             STACK_LIST: []
+        IMAGES: []

--- a/conf/azure.yaml.template
+++ b/conf/azure.yaml.template
@@ -18,6 +18,11 @@ AZURE:
             UNASSIGNED: True
         NIC:
             UNASSIGNED: True
+        IMAGE:
+            # Image name starts with
+            DELETE_PATTERN:
+
+            UNASSIGNED: True
         PUBLIC_IP:
             UNASSIGNED: True
         RESOURCE_GROUP:
@@ -36,3 +41,4 @@ AZURE:
         GROUP:
             # Resource groups that would be skipped from cleanup
             RG_LIST: []
+        IMAGES: []

--- a/conf/azure.yaml.template
+++ b/conf/azure.yaml.template
@@ -20,7 +20,7 @@ AZURE:
             UNASSIGNED: True
         IMAGE:
             # Image name starts with
-            DELETE_PATTERN:
+            DELETE_IMAGE:
 
             UNASSIGNED: True
         PUBLIC_IP:

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -43,6 +43,11 @@ AZURE:
             UNASSIGNED: True
         NIC:
             UNASSIGNED: True
+        IMAGE:
+            # Image name starts with
+            DELETE_PATTERN:
+
+            UNASSIGNED: True
         PUBLIC_IP:
             UNASSIGNED: True
         RESOURCE_GROUP:
@@ -61,6 +66,7 @@ AZURE:
         GROUP:
             # Resource groups that would be skipped from cleanup
             RG_LIST: []
+        IMAGES: []
 
 AWS:
     AUTH:

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -45,7 +45,7 @@ AZURE:
             UNASSIGNED: True
         IMAGE:
             # Image name starts with
-            DELETE_PATTERN:
+            DELETE_IMAGE:
 
             UNASSIGNED: True
         PUBLIC_IP:
@@ -84,6 +84,12 @@ AWS:
             UNASSIGNED: True
         NIC:
             UNASSIGNED: True
+        # Image name starts with
+        IMAGE:
+            # Image name starts with
+            DELETE_IMAGE:
+
+            UNASSIGNED: True
         PUBLIC_IP:
             UNASSIGNED: True
         STACKS:
@@ -100,3 +106,4 @@ AWS:
         STACKS:
             # CloudFormations names that would be skipped from cleanup
             STACK_LIST: []
+        IMAGES: []


### PR DESCRIPTION
Links HMS-2043
- [x] Azure (depends on https://github.com/RedHatQE/wrapanapi/pull/465 )
- [x] AWS

```

(cloudwash) ➜  cloudwash git:(support_image_removal) ✗ swach -d aws --all

<<<<<<< Running the cleanup script in DRY RUN mode >>>>>>>
The AWS providers settings are initialized and validated !

Resources from the region: us-east-1

=========== DRY SUMMARY ============

IMAGES:
	Deletable: ['ami-0ba22849118c7101a', 'ami-03d1c1aee99de0c58']

====================================

(cloudwash) ➜  cloudwash git:(support_image_removal) ✗ swach -d azure --all

<<<<<<< Running the cleanup script in DRY RUN mode >>>>>>>
The AZURE providers settings are initialized and validated !

Resources from the region and resource group: eastus/redhat-deployed

=========== DRY SUMMARY ============

DISCs:
	Deletable: ['composer-api-qwd_disk1_9556a6aca0324ac5adf7e4a700f1c09b']
NICs:
	Deletable: ['composer-api-qwd96']
IMAGES:
	Deletable: ['composer-api-985124e5-b8a9-4969-98ec-400b6af7c924']

====================================

(cloudwash) ➜  cloudwash git:(support_image_removal) ✗ swach azure --all 

<<<<<<< Running the cleanup script in ACTION RUN mode >>>>>>>
The AZURE providers settings are initialized and validated !

Resources from the region and resource group: eastus/redhat-deployed
Stopped VMs: 
[]
Removed VMs: 
[]
Skipped VMs: 
[]
Removed NICs: 
['composer-api-qwd96']
Removed Discs: 
['composer-api-qwd_disk1_9556a6aca0324ac5adf7e4a700f1c09b']
Removed PIPs: 
['composer-api-qwd-ip']
Removed Images: 
['composer-api-985124e5-b8a9-4969-98ec-400b6af7c924']
```

Can't run on aws as we need those images :P 