### PR TITLE
Adding gitleaks pre-commit hook to refrain from pushing secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,7 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
- Gitleaks to catch the secrets being pushed to public repo