### PR TITLE
[bug-fix] mismatch provider name in discs cleaup in `Developer` Branch

### DIFF
--- a/cloudwash/entities/resources/discs.py
+++ b/cloudwash/entities/resources/discs.py
@@ -41,7 +41,7 @@ class CleanAWSDiscs(CleanDiscs):
 
 class CleanAzureDiscs(CleanDiscs):
     def list(self):
-        if settings.aws.criteria.disc.unassigned:
+        if settings.azure.criteria.disc.unassigned:
             rdiscs = self.client.list_free_discs()
             self._delete.extend(rdiscs)
         self._set_dry()


### PR DESCRIPTION
Resolves #129 

To resolve this issue, ensure that the settings configuration is correctly set up and includes the necessary attributes for the specified cloud provider. Review the configuration files and update them accordingly to include the required attributes for Azure resource cleanup.
