### PR TITLE
 Add support for collecting deletable OCP leftovers from AWS

### DIFF
--- a/cloudwash/cli.py
+++ b/cloudwash/cli.py
@@ -98,8 +98,9 @@ def azure(ctx, vms, discs, nics, images, pips, _all, _all_rg):
 @click.option("--images", is_flag=True, help="Remove only images from the provider")
 @click.option("--pips", is_flag=True, help="Remove only Public IPs from the provider")
 @click.option("--stacks", is_flag=True, help="Remove only CloudFormations from the provider")
+@click.option("--ocps", is_flag=True, help="Remove only unused OCPs from the provider")
 @click.pass_context
-def aws(ctx, vms, discs, nics, images, pips, stacks, _all):
+def aws(ctx, vms, discs, nics, images, pips, stacks, ocps, _all):
     # Validate Amazon Settings
     validate_provider(ctx.command.name)
     is_dry_run = ctx.parent.params["dry"]
@@ -110,6 +111,7 @@ def aws(ctx, vms, discs, nics, images, pips, stacks, _all):
         images=images,
         pips=pips,
         stacks=stacks,
+        ocps=ocps,
         _all=_all,
         dry_run=is_dry_run,
     )

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -182,7 +182,9 @@ def cleanup(**kwargs):
             if kwargs["ocps"] or kwargs["_all"]:
                 # Differentiate between the cleanup region to the Resource Explorer client region
                 ocp_client_region = settings.aws.criteria.ocps.ocp_client_region
-                with compute_client("aws", aws_region=ocp_client_region) as resource_explorer_client:
+                with compute_client(
+                    "aws", aws_region=ocp_client_region
+                ) as resource_explorer_client:
                     rocps = dry_ocps()
                     if not is_dry_run:
                         for ocp in rocps:

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -120,22 +120,19 @@ def cleanup(**kwargs):
                             resources=instances,
                         ):
                             dry_data["OCPS"]["delete"].extend(cluster_resources)
-                            dry_data["OCPS"]["clusters"].extend([cluster_name])
                     else:
                         # For resources with no associated EC2 Instances, identify as leftovers
-                        filtered_leftovers = filter_resources_by_time_modified(
-                            time_threshold, resources=cluster_resources
+                        dry_data["OCPS"]["delete"].extend(
+                            filter_resources_by_time_modified(
+                                time_threshold, resources=cluster_resources
+                            )
                         )
-                        if filtered_leftovers:
-                            dry_data["OCPS"]["delete"].extend(filtered_leftovers)
-                            # Print cluster_name only if it's resources are deletable
-                            dry_data["OCPS"]["clusters"].extend([cluster_name])
 
                 # Sort resources by type
                 dry_data["OCPS"]["delete"] = sorted(
                     dry_data["OCPS"]["delete"], key=lambda x: x.resource_type
                 )
-                return dry_data["OCPS"]
+                return dry_data["OCPS"]["delete"]
 
             # Remove / Stop VMs
             def remove_vms(avms):
@@ -186,8 +183,6 @@ def cleanup(**kwargs):
             if kwargs["ocps"] or kwargs["_all"]:
                 # Differentiate between the cleanup region and the Resource Explorer client region
                 ocp_client_region = settings.aws.criteria.ocps.ocp_client_region
-                dry_data["OCPS"]["clusters"] = []
-
                 with compute_client(
                     "aws", aws_region=ocp_client_region
                 ) as resource_explorer_client:

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -105,7 +105,7 @@ def cleanup(**kwargs):
                 return rstacks
 
             def dry_ocps():
-                time_ref = settings.aws.criteria.ocps.sla or "7d"
+                time_ref = settings.aws.criteria.ocps.sla
                 resources = []
 
                 if region:

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -123,7 +123,9 @@ def cleanup(**kwargs):
                     else:
                         # For resources with no associated EC2 Instances, identify as leftovers
                         dry_data["OCPS"]["delete"].extend(
-                            filter_resources_by_time_modified(time_threshold, resources=cluster_resources)
+                            filter_resources_by_time_modified(
+                                time_threshold, resources=cluster_resources
+                            )
                         )
 
                 # Sort resources by type

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -120,19 +120,22 @@ def cleanup(**kwargs):
                             resources=instances,
                         ):
                             dry_data["OCPS"]["delete"].extend(cluster_resources)
+                            dry_data["OCPS"]["clusters"].extend([cluster_name])
                     else:
                         # For resources with no associated EC2 Instances, identify as leftovers
-                        dry_data["OCPS"]["delete"].extend(
-                            filter_resources_by_time_modified(
-                                time_threshold, resources=cluster_resources
-                            )
+                        filtered_leftovers = filter_resources_by_time_modified(
+                            time_threshold, resources=cluster_resources
                         )
+                        if filtered_leftovers:
+                            dry_data["OCPS"]["delete"].extend(filtered_leftovers)
+                            # Print cluster_name only if it's resources are deletable
+                            dry_data["OCPS"]["clusters"].extend([cluster_name])
 
                 # Sort resources by type
                 dry_data["OCPS"]["delete"] = sorted(
                     dry_data["OCPS"]["delete"], key=lambda x: x.resource_type
                 )
-                return dry_data["OCPS"]["delete"]
+                return dry_data["OCPS"]
 
             # Remove / Stop VMs
             def remove_vms(avms):
@@ -183,6 +186,8 @@ def cleanup(**kwargs):
             if kwargs["ocps"] or kwargs["_all"]:
                 # Differentiate between the cleanup region and the Resource Explorer client region
                 ocp_client_region = settings.aws.criteria.ocps.ocp_client_region
+                dry_data["OCPS"]["clusters"] = []
+
                 with compute_client(
                     "aws", aws_region=ocp_client_region
                 ) as resource_explorer_client:

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -108,9 +108,8 @@ def cleanup(**kwargs):
                 time_ref = settings.aws.criteria.ocps.sla
                 resources = []
 
-                if region:
-                    query = " ".join([f"tag.key:{OCP_TAG_SUBSTR}*", f"region:{region}"])
-                    resources = aws_client.list_resources(query=query)
+                query = " ".join([f"tag.key:{OCP_TAG_SUBSTR}*", f"region:{region}"])
+                resources = aws_client.list_resources(query=query)
 
                 # Prepare resources to be filtered before deletion
                 cluster_map = group_ocps_by_cluster(resources=resources)

--- a/cloudwash/providers/aws.py
+++ b/cloudwash/providers/aws.py
@@ -23,7 +23,6 @@ def cleanup(**kwargs):
         dry_data['VMS']['skip'] = []
         for items in data:
             dry_data[items]['delete'] = []
-
         with compute_client("aws", aws_region=region) as aws_client:
             # Dry Data Collection Defs
             def dry_vms():
@@ -180,7 +179,7 @@ def cleanup(**kwargs):
                     remove_stacks(stacks=rstacks)
                     logger.info(f"Removed Stacks: \n{rstacks}")
             if kwargs["ocps"] or kwargs["_all"]:
-                # Differentiate between the cleanup region to the Resource Explorer client region
+                # Differentiate between the cleanup region and the Resource Explorer client region
                 ocp_client_region = settings.aws.criteria.ocps.ocp_client_region
                 with compute_client(
                     "aws", aws_region=ocp_client_region

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -44,6 +44,7 @@ def echo_dry(dry_data=None) -> None:
         ]
         for ocp in dry_data["OCPS"]["delete"]
     }
+    ocp_clusters = dry_data["OCPS"]["clusters"]
     deletable_resources = dry_data["RESOURCES"]["delete"]
     deletable_stacks = dry_data["STACKS"]["delete"] if "STACKS" in dry_data else None
     if deletable_vms or stopable_vms or skipped_vms:
@@ -61,7 +62,7 @@ def echo_dry(dry_data=None) -> None:
     if deletable_pips:
         logger.info(f"PIPs:\n\tDeletable: {deletable_pips}")
     if deletable_ocps:
-        logger.info(f"OCPs:\n\tDeletable: {deletable_ocps}")
+        logger.info(f"OCPs:\n\tDeletable: {deletable_ocps}\n\tClusters: {ocp_clusters}")
     if deletable_resources:
         logger.info(f"RESOURCEs:\n\tDeletable: {deletable_resources}")
     if deletable_stacks:
@@ -76,6 +77,7 @@ def echo_dry(dry_data=None) -> None:
             deletable_resources,
             deletable_stacks,
             deletable_images,
+            deletable_ocps,
         ]
     ):
         logger.info("\nNo resources are eligible for cleanup!")
@@ -172,7 +174,7 @@ def calculate_time_threshold(time_ref=""):
 
     # Time Ref is Optional; if empty, time_threshold will be set as "now"
     time_threshold = dateparser.parse(f"now-{time_ref}-UTC")
-    logger.info(
+    logger.debug(
         f"\nAssociated OCP resources are filtered by last creation time of: {time_threshold}"
     )
     return time_threshold
@@ -186,7 +188,6 @@ def filter_resources_by_time_modified(
     Filter list of AWS resources by checking modification date ("LastReportedAt")
     :param datetime time_threshold: Time filtering criteria
     :param list resources: List of resources to be filtered out
-
 
     :return: list of resources that last modified before time threshold
 

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -166,6 +166,8 @@ def filter_resources_by_time_modified(
         Use the time_ref "1h" to collect resources that exist for more than an hour
     """
     filtered_resources = []
+    if time_ref is None:
+        time_ref = ""
 
     if time_ref.isnumeric():
         # Use default time value as Minutes

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -2,19 +2,25 @@
 from collections import namedtuple
 from datetime import datetime
 
+import dateparser
 import pytz
+from wrapanapi.systems.ec2 import ResourceExplorerResource
 
 from cloudwash.logger import logger
+
+OCP_TAG_SUBSTR = "kubernetes.io/cluster/"
 
 _vms_dict = {"VMS": {"delete": [], "stop": [], "skip": []}}
 dry_data = {
     "NICS": {"delete": []},
     "DISCS": {"delete": []},
     "PIPS": {"delete": []},
+    "OCPS": {"delete": []},
     "RESOURCES": {"delete": []},
     "STACKS": {"delete": []},
     "IMAGES": {"delete": []},
 }
+
 dry_data.update(_vms_dict)
 
 
@@ -32,6 +38,12 @@ def echo_dry(dry_data=None) -> None:
     deletable_nics = dry_data["NICS"]["delete"]
     deletable_images = dry_data["IMAGES"]["delete"]
     deletable_pips = dry_data["PIPS"]["delete"] if "PIPS" in dry_data else None
+    deletable_ocps = {
+        ocp.resource_type: [
+            r.name for r in dry_data["OCPS"]["delete"] if r.resource_type == ocp.resource_type
+        ]
+        for ocp in dry_data["OCPS"]["delete"]
+    }
     deletable_resources = dry_data["RESOURCES"]["delete"]
     deletable_stacks = dry_data["STACKS"]["delete"] if "STACKS" in dry_data else None
     if deletable_vms or stopable_vms or skipped_vms:
@@ -39,6 +51,7 @@ def echo_dry(dry_data=None) -> None:
             f"VMs:\n\tDeletable: {deletable_vms}\n\tStoppable: {stopable_vms}\n\t"
             f"Skip: {skipped_vms}"
         )
+
     if deletable_discs:
         logger.info(f"DISCs:\n\tDeletable: {deletable_discs}")
     if deletable_nics:
@@ -47,6 +60,8 @@ def echo_dry(dry_data=None) -> None:
         logger.info(f"IMAGES:\n\tDeletable: {deletable_images}")
     if deletable_pips:
         logger.info(f"PIPs:\n\tDeletable: {deletable_pips}")
+    if deletable_ocps:
+        logger.info(f"OCPs:\n\tDeletable: {deletable_ocps}")
     if deletable_resources:
         logger.info(f"RESOURCEs:\n\tDeletable: {deletable_resources}")
     if deletable_stacks:
@@ -112,3 +127,61 @@ def gce_zones() -> list:
     _zones_combo = {**_bcds, **_abcfs, **_abcs}
     zones = [f"{loc}-{zone}" for loc, zones in _zones_combo.items() for zone in zones]
     return zones
+
+
+def group_ocps_by_cluster(resources=None) -> dict:
+    clusters_map = {}
+
+    for resource in resources:
+        for key in resource.get_tags(regex=OCP_TAG_SUBSTR):
+            cluster_name = key.get("Key")
+            if OCP_TAG_SUBSTR in cluster_name:
+                cluster_name = cluster_name.split(OCP_TAG_SUBSTR)[1]
+                if cluster_name not in clusters_map.keys():
+                    clusters_map[cluster_name] = {"Resources": [], "Instances": []}
+
+                # Set cluster's EC2 instances
+                if hasattr(resource, 'ec2_instance'):
+                    clusters_map[cluster_name]["Instances"].append(resource)
+                # Set resource under cluster
+                else:
+                    clusters_map[cluster_name]["Resources"].append(resource)
+    return clusters_map
+
+
+def filter_resources_by_time_modified(
+    resources: list[ResourceExplorerResource] = None, time_ref=""
+) -> list:
+    """
+    Filter list of AWS resources by checking modification date ("LastReportedAt")
+
+    :param list resources: List of resources to be filtered out
+    :param str time_ref: a relative time reference for indicating the filter value
+        of a relative time, given in a {time_value}{time_unit} format; default is "" (no filtering)
+
+
+    :return: list of resources that last modified before time threshold
+
+    :Example:
+        Use the time_ref "1h" to collect resources that exist for more than an hour
+    """
+    filtered_resources = []
+
+    if time_ref.isnumeric():
+        # Use default time value as Minutes
+        time_ref += "m"
+
+    # Time Ref is Optional; if empty, time_threshold will be set as "now"
+    time_threshold = dateparser.parse(f"now-{time_ref}-UTC")
+
+    for resource in resources:
+        # Will not collect resources recorded during the SLA time
+        if resource.date_modified > time_threshold:
+            continue
+        filtered_resources.append(resource)
+    return filtered_resources
+
+
+def delete_ocp(ocp):
+    # WIP: add support for deletion
+    pass

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -129,7 +129,14 @@ def gce_zones() -> list:
     return zones
 
 
-def group_ocps_by_cluster(resources=None) -> dict:
+def group_ocps_by_cluster(resources: list = None) -> dict:
+    """Group different types of AWS resources under their original OCP clusters
+
+    :param list resources: AWS resources collected by defined region and sla
+    :return: A dictionary with the clusters as keys and the associated resources as values
+    """
+    if resources is None:
+        resources = []
     clusters_map = {}
 
     for resource in resources:

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -156,23 +156,13 @@ def group_ocps_by_cluster(resources: list = None) -> dict:
     return clusters_map
 
 
-def filter_resources_by_time_modified(
-    resources: list[ResourceExplorerResource] = None, time_ref=""
-) -> list:
-    """
-    Filter list of AWS resources by checking modification date ("LastReportedAt")
+def calculate_time_threshold(time_ref=""):
+    """Parses a time reference for data filtering
 
-    :param list resources: List of resources to be filtered out
     :param str time_ref: a relative time reference for indicating the filter value
-        of a relative time, given in a {time_value}{time_unit} format; default is "" (no filtering)
-
-
-    :return: list of resources that last modified before time threshold
-
-    :Example:
-        Use the time_ref "1h" to collect resources that exist for more than an hour
+    of a relative time, given in a {time_value}{time_unit} format; default is "" (no filtering)
+    :return datetime time_threshold
     """
-    filtered_resources = []
     if time_ref is None:
         time_ref = ""
 
@@ -182,6 +172,28 @@ def filter_resources_by_time_modified(
 
     # Time Ref is Optional; if empty, time_threshold will be set as "now"
     time_threshold = dateparser.parse(f"now-{time_ref}-UTC")
+    logger.info(
+        f"\nAssociated OCP resources are filtered by last creation time of: {time_threshold}"
+    )
+    return time_threshold
+
+
+def filter_resources_by_time_modified(
+    time_threshold,
+    resources: list[ResourceExplorerResource] = None,
+) -> list:
+    """
+    Filter list of AWS resources by checking modification date ("LastReportedAt")
+    :param datetime time_threshold: Time filtering criteria
+    :param list resources: List of resources to be filtered out
+
+
+    :return: list of resources that last modified before time threshold
+
+    :Example:
+        Use the time_ref "1h" to collect resources that exist for more than an hour
+    """
+    filtered_resources = []
 
     for resource in resources:
         # Will not collect resources recorded during the SLA time

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -76,6 +76,7 @@ def echo_dry(dry_data=None) -> None:
             deletable_resources,
             deletable_stacks,
             deletable_images,
+            deletable_ocps,
         ]
     ):
         logger.info("\nNo resources are eligible for cleanup!")
@@ -172,7 +173,7 @@ def calculate_time_threshold(time_ref=""):
 
     # Time Ref is Optional; if empty, time_threshold will be set as "now"
     time_threshold = dateparser.parse(f"now-{time_ref}-UTC")
-    logger.info(
+    logger.debug(
         f"\nAssociated OCP resources are filtered by last creation time of: {time_threshold}"
     )
     return time_threshold
@@ -186,7 +187,6 @@ def filter_resources_by_time_modified(
     Filter list of AWS resources by checking modification date ("LastReportedAt")
     :param datetime time_threshold: Time filtering criteria
     :param list resources: List of resources to be filtered out
-
 
     :return: list of resources that last modified before time threshold
 

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -44,7 +44,6 @@ def echo_dry(dry_data=None) -> None:
         ]
         for ocp in dry_data["OCPS"]["delete"]
     }
-    ocp_clusters = dry_data["OCPS"]["clusters"]
     deletable_resources = dry_data["RESOURCES"]["delete"]
     deletable_stacks = dry_data["STACKS"]["delete"] if "STACKS" in dry_data else None
     if deletable_vms or stopable_vms or skipped_vms:
@@ -62,7 +61,7 @@ def echo_dry(dry_data=None) -> None:
     if deletable_pips:
         logger.info(f"PIPs:\n\tDeletable: {deletable_pips}")
     if deletable_ocps:
-        logger.info(f"OCPs:\n\tDeletable: {deletable_ocps}\n\tClusters: {ocp_clusters}")
+        logger.info(f"OCPs:\n\tDeletable: {deletable_ocps}")
     if deletable_resources:
         logger.info(f"RESOURCEs:\n\tDeletable: {deletable_resources}")
     if deletable_stacks:
@@ -77,7 +76,6 @@ def echo_dry(dry_data=None) -> None:
             deletable_resources,
             deletable_stacks,
             deletable_images,
-            deletable_ocps,
         ]
     ):
         logger.info("\nNo resources are eligible for cleanup!")
@@ -174,7 +172,7 @@ def calculate_time_threshold(time_ref=""):
 
     # Time Ref is Optional; if empty, time_threshold will be set as "now"
     time_threshold = dateparser.parse(f"now-{time_ref}-UTC")
-    logger.debug(
+    logger.info(
         f"\nAssociated OCP resources are filtered by last creation time of: {time_threshold}"
     )
     return time_threshold
@@ -188,6 +186,7 @@ def filter_resources_by_time_modified(
     Filter list of AWS resources by checking modification date ("LastReportedAt")
     :param datetime time_threshold: Time filtering criteria
     :param list resources: List of resources to be filtered out
+
 
     :return: list of resources that last modified before time threshold
 

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -100,7 +100,7 @@ AWS:
             SLA_MINUTES: 120
         OCPS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
-            SLA:
+            SLA: 7d
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -74,7 +74,6 @@ AWS:
         SECRET_KEY:
         # Multiple regions can be added like ["ap-south-1", "us-west-2", "us-west-1"] or ["all"] for all regions
         REGIONS: [] # Cleanup regions
-        CLIENT_REGION: "us-east-1"
     CRITERIA:
         VM:
             # The VM to be deleted with prepend string, e.g VM name that starts with 'test'
@@ -99,6 +98,7 @@ AWS:
             # Number of minutes the deletable CloudFormation should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
         OCPS:
+            OCP_CLIENT_REGION: "us-east-1"
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -100,6 +100,7 @@ AWS:
             SLA_MINUTES: 120
         OCPS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
+            # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
     EXCEPTIONS:
         VM:

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -73,7 +73,8 @@ AWS:
         ACCESS_KEY:
         SECRET_KEY:
         # Multiple regions can be added like ["ap-south-1", "us-west-2", "us-west-1"] or ["all"] for all regions
-        REGIONS: []
+        REGIONS: [] # Cleanup regions
+        CLIENT_REGION: "us-east-1"
     CRITERIA:
         VM:
             # The VM to be deleted with prepend string, e.g VM name that starts with 'test'
@@ -97,6 +98,9 @@ AWS:
             DELETE_STACK: 'test'
             # Number of minutes the deletable CloudFormation should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
+        OCPS:
+            # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
+            SLA:
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup


### PR DESCRIPTION
Main flow:

1. Fetching OCP resources using [RedHatQe/wrapnapi](https://github.com/RedHatQE/wrapanapi/blob/master/wrapanapi/systems/ec2.py#L1810)

   - AWS Resource Explorer official docs:
    - https://docs.aws.amazon.com/resource-explorer/latest/userguide/welcome.html

2. Filtering resources using the `kubernetes.io/cluster/*` tag regex
3. Resources without associated EC2 Instances considered as leftovers
    - Filtered by the last time modified
4. Resources associated with EC2 Instances are filtered by their EC2 Instances time modified
5. **For simplicity- deletion process will be separated by a following PR**