### PR TITLE
Cloudwash supporting Containers cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ cloudwash supports following cloud providers:
 * VMWare vCenter (_Support yet To be added_)
 * OCP Clusters deplyed on Public clouds (_Support yet To be added_)
 
+And the Containerization tools:
+
+* Podman
+
 The list of resource types it helps to clean could be found under settings.yaml.template](https://github.com/RedHatQE/cloudwash/blob/master/settings.yaml.template) file for individual cloud providers along with cleanup criteria.
 
 ## Installation
@@ -104,6 +108,7 @@ azure		Cleanup Azure provider
 aws			Cleanup Amazon provider
 gce			Cleanup GCE provider
 openstack	Cleanup OSP provider
+podman      Cleanup Podman provider
 rhev 		Cleanup RHEV provider
 vmware 		Cleanup VMWare provider
 ```

--- a/cloudwash/cli.py
+++ b/cloudwash/cli.py
@@ -6,6 +6,7 @@ from cloudwash.logger import logger
 from cloudwash.providers.aws import cleanup as awsCleanup
 from cloudwash.providers.azure import cleanup as azureCleanup
 from cloudwash.providers.gce import cleanup as gceCleanup
+from cloudwash.providers.podman import cleanup as podmanCleanup
 
 # Adding the pythonpath for importing modules from cloudwash packages
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
@@ -111,6 +112,19 @@ def aws(ctx, vms, discs, nics, images, pips, stacks, _all):
         pips=pips,
         stacks=stacks,
         _all=_all,
+        dry_run=is_dry_run,
+    )
+
+
+@cleanup_providers.command(help="Cleanup Podman provider")
+@click.option("--containers", is_flag=True, help="Remove containers from the podman host")
+@click.pass_context
+def podman(ctx, containers):
+    # Validate Podman Settings
+    validate_provider(ctx.command.name)
+    is_dry_run = ctx.parent.params["dry"]
+    podmanCleanup(
+        containers=containers,
         dry_run=is_dry_run,
     )
 

--- a/cloudwash/client.py
+++ b/cloudwash/client.py
@@ -34,11 +34,16 @@ def compute_client(compute_resource, **kwargs):
             password=settings.aws.auth.secret_key,
             region=kwargs['aws_region'],
         )
+    elif compute_resource == "podman":
+        client = wrapanapi.Podman(
+            hostname=settings.podman.auth.hostname,
+            username=settings.podman.auth.username,
+            port=settings.podman.auth.ssh_port,
+        )
     else:
         raise ValueError(
             f"{compute_resource} is an incorrect value. It should be one of azure or gce or ec2"
         )
-
     try:
         yield client
     finally:

--- a/cloudwash/constants.py
+++ b/cloudwash/constants.py
@@ -1,3 +1,4 @@
 aws_data = ['VMS', 'NICS', 'DISCS', 'PIPS', 'RESOURCES', 'STACKS']
 azure_data = ['VMS', 'NICS', 'DISCS', 'IMAGES', 'PIPS', 'RESOURCES']
 gce_data = ['VMS', 'NICS', 'DISCS']
+container_data = ['CONTAINERS']

--- a/cloudwash/entities/providers.py
+++ b/cloudwash/entities/providers.py
@@ -1,3 +1,4 @@
+from cloudwash.entities.resources.containers import CleanPodmanContainers
 from cloudwash.entities.resources.discs import CleanAWSDiscs
 from cloudwash.entities.resources.discs import CleanAzureDiscs
 from cloudwash.entities.resources.images import CleanAWSImages
@@ -81,3 +82,13 @@ class GCECleanup(providerCleanup):
     def __init__(self, client):
         self.client = client
         super().__init__(client)
+
+
+class PodmanCleanup(providerCleanup):
+    def __init__(self, client):
+        self.client = client
+        super().__init__(client)
+
+    @property
+    def containers(self):
+        return CleanPodmanContainers(client=self.client)

--- a/cloudwash/entities/resources/base.py
+++ b/cloudwash/entities/resources/base.py
@@ -132,6 +132,32 @@ class VMsCleanup(ResourceCleanup):
         pass
 
 
+class ContainerCleanup(ResourceCleanup):
+    @abstractmethod
+    def list(self):
+        pass
+
+    @abstractmethod
+    def cleanup(self):
+        pass
+
+    @abstractmethod
+    def stop(self):
+        pass
+
+    @abstractmethod
+    def remove(self):
+        pass
+
+    @abstractmethod
+    def skip(self):
+        pass
+
+    @abstractmethod
+    def _set_dry(self):
+        pass
+
+
 class ResourceCleanupManager:
     def __init__(self):
         self.resources = []

--- a/cloudwash/entities/resources/containers.py
+++ b/cloudwash/entities/resources/containers.py
@@ -1,0 +1,60 @@
+from cloudwash.config import settings
+from cloudwash.entities.resources.base import ContainerCleanup
+from cloudwash.logger import logger
+from cloudwash.utils import dry_data
+from cloudwash.utils import total_running_time
+
+
+class CleanContainers(ContainerCleanup):
+    def __init__(self, client):
+        self.client = client
+        self._delete = []
+        self._stop = []
+        self._skip = []
+        self.list()
+
+    def _set_dry(self):
+        dry_data['CONTAINERS']['delete'] = self._delete
+        dry_data['CONTAINERS']['stop'] = self._stop
+        dry_data['CONTAINERS']['skip'] = self._skip
+
+    def list(self):
+        pass
+
+    def stop(self):
+        for container in self._stop:
+            self.client.get_container(key=container).stop()
+        logger.info(f"Stopped Podman Containers: \n{self._stop}")
+
+    def remove(self):
+        for container in self._delete:
+            self.client.get_container(key=container).delete(force=True)
+        logger.info(f"Removed Podman Containers: \n{self._delete}")
+
+    def skip(self):
+        logger.info(f"Skipped VMs: \n{self._skip}")
+
+    def cleanup(self):
+        if not settings.dry_run:
+            self.remove()
+            self.stop()
+            self.skip()
+
+
+class CleanPodmanContainers(CleanContainers):
+    def list(self):
+
+        for container in self.client.containers:
+            if container.name in settings.podman.exceptions.container.skip_list:
+                self._skip.append(container.name)
+                continue
+            elif total_running_time(container).minutes >= settings.podman.criteria.container.sla:
+
+                if container.name in settings.podman.exceptions.container.stop_list:
+                    self._stop.append(container.name)
+                    continue
+
+                elif container.name.startswith(settings.podman.criteria.container.name_prefix):
+                    self._delete.append(container.name)
+
+        self._set_dry()

--- a/cloudwash/providers/podman.py
+++ b/cloudwash/providers/podman.py
@@ -1,0 +1,19 @@
+"""Azure CR Cleanup Utilities"""
+from cloudwash.client import compute_client
+from cloudwash.constants import container_data as data
+from cloudwash.entities.providers import PodmanCleanup
+from cloudwash.utils import dry_data
+from cloudwash.utils import echo_dry
+
+
+def cleanup(**kwargs):
+    is_dry_run = kwargs.get("dry_run", False)
+    for items in data:
+        dry_data[items]['delete'] = []
+    with compute_client("podman") as podman_client:
+        podmancleanup = PodmanCleanup(client=podman_client)
+        # Actual Cleaning and dry execution
+        if kwargs["containers"]:
+            podmancleanup.containers.cleanup()
+        if is_dry_run:
+            echo_dry(dry_data)

--- a/cloudwash/utils.py
+++ b/cloudwash/utils.py
@@ -7,6 +7,8 @@ import pytz
 from cloudwash.logger import logger
 
 _vms_dict = {"VMS": {"delete": [], "stop": [], "skip": []}}
+_containers_dict = {"CONTAINERS": {"delete": [], "stop": [], "skip": []}}
+
 dry_data = {
     "NICS": {"delete": []},
     "DISCS": {"delete": []},
@@ -16,6 +18,7 @@ dry_data = {
     "IMAGES": {"delete": []},
 }
 dry_data.update(_vms_dict)
+dry_data.update(_containers_dict)
 
 
 def echo_dry(dry_data=None) -> None:
@@ -28,6 +31,9 @@ def echo_dry(dry_data=None) -> None:
     deletable_vms = dry_data["VMS"]["delete"]
     stopable_vms = dry_data["VMS"]["stop"]
     skipped_vms = dry_data["VMS"]["skip"]
+    deletable_containers = dry_data["CONTAINERS"]["delete"]
+    stopable_containers = dry_data["CONTAINERS"]["stop"]
+    skipped_containers = dry_data["CONTAINERS"]["skip"]
     deletable_discs = dry_data["DISCS"]["delete"]
     deletable_nics = dry_data["NICS"]["delete"]
     deletable_images = dry_data["IMAGES"]["delete"]
@@ -38,6 +44,12 @@ def echo_dry(dry_data=None) -> None:
         logger.info(
             f"VMs:\n\tDeletable: {deletable_vms}\n\tStoppable: {stopable_vms}\n\t"
             f"Skip: {skipped_vms}"
+        )
+    if deletable_containers or stopable_containers or skipped_containers:
+        logger.info(
+            f"Containers:\n\tDeletable: {deletable_containers}\n\t"
+            f"Stoppable: {stopable_containers}\n\t"
+            f"Skip: {skipped_containers}"
         )
     if deletable_discs:
         logger.info(f"DISCs:\n\tDeletable: {deletable_discs}")
@@ -61,6 +73,9 @@ def echo_dry(dry_data=None) -> None:
             deletable_resources,
             deletable_stacks,
             deletable_images,
+            deletable_containers,
+            stopable_containers,
+            skipped_containers,
         ]
     ):
         logger.info("\nNo resources are eligible for cleanup!")

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -109,3 +109,20 @@ AWS:
             # CloudFormations names that would be skipped from cleanup
             STACK_LIST: []
         IMAGES: []
+PODMAN:
+    AUTH:
+        HOSTNAME:
+        USERNAME: root
+        SSH_PORT: 22
+    CRITERIA:
+        CONTAINER:
+            # Container Prepended Test
+            NAME_PREFIX: 'satci'
+            # Container running time in minutes
+            SLA: 720
+    EXCEPTIONS:
+        CONTAINER:
+            # Containers to skip and not to delete
+            SKIP_LIST: []
+            # Containers to stop if running but not delete
+            STOP_LIST: []


### PR DESCRIPTION
This PR adds :
- Support is added for new podman provider and new container resource-type

Depends on:
- https://github.com/RedHatQE/wrapanapi/pull/490/ 

Logs:
```
# swach -d podman --containers         

<<<<<<< Running the cleanup script in DRY mode >>>>>>>
The PODMAN providers settings are initialized and validated !

=========== DRY SUMMARY ============

Containers:
	Deletable: ['satci_028317bd', 'satci_05fcf328', 'satci_45d36389', 'satci_df218a23', 'satci_8495c229', 'satci_debadcd2', 'satci_279c111d', 'satci_13764a88', 'satci_6a90dcca', 'satci_cfdb58e3', 'satci_950b969d', 'satci_8e69c381', 'satci_3bac0d80', 'satci_6951fafd', 'satci_54597423', 'satci_a239bf73', 'satci_03422a78', 'satci_47a081d8', 'satci_553965b8', 'satci_dca3fb4e', 'satci_93506f68', 'satci_f17523aa', 'satci_44dfd3cf', 'satci_8ef89ca1', 'satci_fec8032a', 'satci_71ca0e98', 'satci_465b3692', 'satci_5245242e', 'satci_48af3299', 'satci_fc74a3c5', 'satci_672b9d54', 'satci_051286ba', 'satci_56f0b9e2', 'satci_f19698c3', 'satci_89deffd9', 'satci_1e0b413e', 'satci_1f2b1c80', 'satci_1234a2e4', 'satci_aa98f3ed', 'satci_6b5c5780', 'satci_5a7e3203', 'satci_53ee897e', 'satci_e29a3715', 'satci_b71b4ecb', 'satci_9603686c', 'satci_d66312ab', 'satci_144a4140', 'satci_3d28f589', 'satci_54751d9b', 'satci_56f6eaf3', 'satci_63120e1d', 'satci_f7085532', 'satci_553587ae', 'satci_cca812ad', 'satci_c96cc920', 'satci_5798db25', 'satci_0fa321f5', 'satci_399c54ba', 'satci_a1df9b21', 'satci_aae6c308', 'satci_e4671733', 'satci_8fa19cf1', 'satci_46f480d9', 'satci_3dab1e6f']
	Stoppable: []
	Skip: []

====================================

```