### PR TITLE
Add OCPs to conf/aws.yaml.template file

### DIFF
--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -26,6 +26,11 @@ AWS:
             DELETE_STACK: 'test'
             # Number of minutes the deletable CloudFormation should be allowed to live, e.g 120 minutes = 2 Hours
             SLA_MINUTES: 120
+        OCPS:
+            OCP_CLIENT_REGION: "us-east-1"
+            # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
+            # If a time unit is not specified (the value is numeric), it will be considered as Minutes
+            SLA: 7d
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup


### PR DESCRIPTION
This file is out of date with the latest OCPs support.

This addition allows us to work with env vars and avoid using `settings.yaml` directly.