### PR TITLE
Allow filter by cluster prefix

### DIFF
--- a/cloudwash/entities/resources/ocps.py
+++ b/cloudwash/entities/resources/ocps.py
@@ -34,7 +34,9 @@ class CleanAWSOcps(CleanOCPs):
 
         ocp_prefix = list(settings.aws.criteria.ocps.ocp_prefix) or [""]
         for prefix in ocp_prefix:
-            query = " ".join([f"tag.key:{OCP_TAG_SUBSTR}{prefix}*", f"region:{self.client.cleaning_region}"])
+            query = " ".join(
+                [f"tag.key:{OCP_TAG_SUBSTR}{prefix}*", f"region:{self.client.cleaning_region}"]
+            )
             resources.extend(self.client.list_resources(query=query))
 
         # Prepare resources to be filtered before deletion

--- a/cloudwash/entities/resources/ocps.py
+++ b/cloudwash/entities/resources/ocps.py
@@ -30,9 +30,9 @@ class CleanOCPs(OCPsCleanup):
 class CleanAWSOcps(CleanOCPs):
     def list(self):
         resources = []
-        time_threshold = calculate_time_threshold(time_ref=settings.aws.criteria.ocps.sla)
+        time_threshold = calculate_time_threshold(time_ref=settings.aws.criteria.ocps.get("SLA"))
 
-        ocp_prefix = list(settings.aws.criteria.ocps.ocp_prefix) or [""]
+        ocp_prefix = list(settings.aws.criteria.ocps.get("OCP_PREFIXES") or [""])
         for prefix in ocp_prefix:
             query = " ".join(
                 [f"tag.key:{OCP_TAG_SUBSTR}{prefix}*", f"region:{self.client.cleaning_region}"]

--- a/cloudwash/entities/resources/ocps.py
+++ b/cloudwash/entities/resources/ocps.py
@@ -29,12 +29,13 @@ class CleanOCPs(OCPsCleanup):
 
 class CleanAWSOcps(CleanOCPs):
     def list(self):
+        resources = []
         time_threshold = calculate_time_threshold(time_ref=settings.aws.criteria.ocps.sla)
 
-        ocp_prefix = settings.aws.criteria.ocps.ocp_prefix or ""
-        query = " ".join([f"tag.key:{OCP_TAG_SUBSTR}{ocp_prefix}*", f"region:{self.client.cleaning_region}"])
-
-        resources = self.client.list_resources(query=query)
+        ocp_prefix = list(settings.aws.criteria.ocps.ocp_prefix) or [""]
+        for prefix in ocp_prefix:
+            query = " ".join([f"tag.key:{OCP_TAG_SUBSTR}{prefix}*", f"region:{self.client.cleaning_region}"])
+            resources.extend(self.client.list_resources(query=query))
 
         # Prepare resources to be filtered before deletion
         cluster_map = group_ocps_by_cluster(resources=resources)

--- a/cloudwash/entities/resources/ocps.py
+++ b/cloudwash/entities/resources/ocps.py
@@ -31,7 +31,9 @@ class CleanAWSOcps(CleanOCPs):
     def list(self):
         time_threshold = calculate_time_threshold(time_ref=settings.aws.criteria.ocps.sla)
 
-        query = " ".join([f"tag.key:{OCP_TAG_SUBSTR}*", f"region:{self.client.cleaning_region}"])
+        ocp_prefix = settings.aws.criteria.ocps.ocp_prefix or ""
+        query = " ".join([f"tag.key:{OCP_TAG_SUBSTR}{ocp_prefix}*", f"region:{self.client.cleaning_region}"])
+
         resources = self.client.list_resources(query=query)
 
         # Prepare resources to be filtered before deletion

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -31,6 +31,9 @@ AWS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
+            # Specify OCP clusters prefix to filter by, for example: "my_project_", "openshift-" etc..
+            # Don't use '*' to express the use of a prefix
+            OCP_PREFIX:
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -31,9 +31,9 @@ AWS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
-            # Specify OCP clusters prefix to filter by, for example: "my_project_", "openshift-" etc..
+            # Specify OCP clusters prefix to filter by, for example: '["my_project_", "openshift-"]' etc..
             # Don't use '*' to express the use of a prefix
-            OCP_PREFIX:
+            OCP_PREFIX: '[]'
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -33,7 +33,7 @@ AWS:
             SLA: 7d
             # Specify OCP clusters prefix to filter by, for example: ["my_project_", "openshift-"] etc..
             # Don't use '*' to express the use of a prefix
-            OCP_PREFIX: []
+            OCP_PREFIXES: []
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -31,9 +31,9 @@ AWS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
-            # Specify OCP clusters prefix to filter by, for example: ["my_project_", "openshift-"] etc..
+            # Specify OCP clusters prefix to filter by, for example: '["my_project_", "openshift-"]' etc..
             # Don't use '*' to express the use of a prefix
-            OCP_PREFIXES: []
+            OCP_PREFIXES: '[]'
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -32,8 +32,9 @@ AWS:
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
             # Specify OCP clusters prefix to filter by, for example: '["my_project_", "openshift-"]' etc..
-            # Don't use '*' to express the use of a prefix
-            OCP_PREFIXES: '[]'
+            # Regular expression based prefix is not supported
+            # Won't be considered if not given
+            OCP_PREFIXES: []
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/conf/aws.yaml.template
+++ b/conf/aws.yaml.template
@@ -31,9 +31,9 @@ AWS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
-            # Specify OCP clusters prefix to filter by, for example: '["my_project_", "openshift-"]' etc..
+            # Specify OCP clusters prefix to filter by, for example: ["my_project_", "openshift-"] etc..
             # Don't use '*' to express the use of a prefix
-            OCP_PREFIX: '[]'
+            OCP_PREFIX: []
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -105,7 +105,8 @@ AWS:
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
             # Specify OCP clusters prefix to filter by, for example: ["my_project_", "openshift-"] etc..
-            # Don't use '*' to express the use of a prefix
+            # Regular expression based prefix is not supported
+            # Won't be considered if not given
             OCP_PREFIXES: []
     EXCEPTIONS:
         VM:

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -104,6 +104,9 @@ AWS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
+            # Specify OCP clusters prefix to filter by, for example: "my_project_", "openshift-" etc..
+            # Don't use '*' to express the use of a prefix
+            OCP_PREFIX:
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -106,7 +106,7 @@ AWS:
             SLA: 7d
             # Specify OCP clusters prefix to filter by, for example: ["my_project_", "openshift-"] etc..
             # Don't use '*' to express the use of a prefix
-            OCP_PREFIX: []
+            OCP_PREFIXES: []
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -104,9 +104,9 @@ AWS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
-            # Specify OCP clusters prefix to filter by, for example: "my_project_", "openshift-" etc..
+            # Specify OCP clusters prefix to filter by, for example: '["my_project_", "openshift-"]' etc..
             # Don't use '*' to express the use of a prefix
-            OCP_PREFIX:
+            OCP_PREFIX: '[]'
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup

--- a/settings.yaml.template
+++ b/settings.yaml.template
@@ -104,9 +104,9 @@ AWS:
             # Specified as {time_value}{time_unit} format, e.g. "7d" = 7 Days
             # If a time unit is not specified (the value is numeric), it will be considered as Minutes
             SLA: 7d
-            # Specify OCP clusters prefix to filter by, for example: '["my_project_", "openshift-"]' etc..
+            # Specify OCP clusters prefix to filter by, for example: ["my_project_", "openshift-"] etc..
             # Don't use '*' to express the use of a prefix
-            OCP_PREFIX: '[]'
+            OCP_PREFIX: []
     EXCEPTIONS:
         VM:
             # VM names that would be skipped from cleanup


### PR DESCRIPTION
Filter resources by ocp cluster prefix.
This is important when we want to free up resources in the context of a project or any associated key value.

Can be used with env var with specifying:
`export CLEANUP_AWS__CRITERIA__OCPS__OCP_PREFIX='["ocp-cluster-prefix"]'  `